### PR TITLE
Allow thumb_img override.

### DIFF
--- a/lazyYT.js
+++ b/lazyYT.js
@@ -76,6 +76,9 @@
         })
           .html(innerHtml.join(''));
         
+      if ($el.data('thumb-img')) {
+          thumb_img = $el.data('thumb-img') + ".jpg";
+      } else {
         if (width > 640) {
           thumb_img = 'maxresdefault.jpg';
         } else if (width > 480) {
@@ -89,6 +92,8 @@
         } else {
           thumb_img = 'default.jpg';
         }
+      }
+
         
         $thumb = $el.find('.ytp-thumbnail').css({
             'background-image': ['url(http://img.youtube.com/vi/', id, '/', thumb_img, ')'].join('')


### PR DESCRIPTION
Allow an override to load a specified thumb_img rather than relying on width. This allows an iframe to be full width but still load a thumb if the hddefault thumb does not exist.

`<div class="lazyYT" data-youtube-id="{{ id }}" data-thumb-img="sddefault"></div>`